### PR TITLE
Fix problem with 'set -e'

### DIFF
--- a/scripts/ceilometer/check_ceilometer-agent-compute.sh
+++ b/scripts/ceilometer/check_ceilometer-agent-compute.sh
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-set -e
 
 STATE_OK=0
 STATE_WARNING=1


### PR DESCRIPTION
line 23 'set -e' cause the script to exit:

PID=$(pidof -x $DEAMON)
if [ -z $PID ]; then
    echo "$DEAMON is not running."
    exit $STATE_CRITICAL
fi

PID=$(pidof -x $DEAMON)  <- if $DEAMON doesn't exist, the script exit because of the 'set -e' (non-zero value returned).
