### PR TITLE
[ceilometer] replaced meters by projects URI, check is faster

### DIFF
--- a/scripts/ceilometer/check_ceilometer_api_curl.sh
+++ b/scripts/ceilometer/check_ceilometer_api_curl.sh
@@ -88,6 +88,12 @@ if [ -z "$TOKEN2" ]; then
     exit $STATE_CRITICAL
 fi
 
-RES=$(curl -s -H "X-Auth-Token: $TOKEN2" -H 'Content-Type: application/json' ${ENDPOINT_URL}/meters | grep -o user_id -c)
+RES=$(curl -s -H "X-Auth-Token: $TOKEN2" -H 'Content-Type: application/json' ${ENDPOINT_URL}/projects | grep -o project -c)                                                                                                       
 
-echo "Ceilometer API is working with $RES meters."
+if [ -z "$RES" ]; then
+    echo "Unable to get projects"
+    exit $STATE_CRITICAL
+else
+    echo "Ceilometer API is working." 
+fi
+


### PR DESCRIPTION
Ceilometer API check was very slow because of the mongodb database, i changed the URI (meters to projects).

projects return an answer quickly than meters
