### PR TITLE
[glance-api] Add curl error handling on API calls to avoid python tracebacks

### DIFF
--- a/scripts/glance/check_glance-api.sh
+++ b/scripts/glance/check_glance-api.sh
@@ -5,6 +5,7 @@
 # Copyright © 2013 eNovance <licensing@enovance.com>
 #
 # Author: Emilien Macchi <emilien.macchi@enovance.com>
+#         Nicolas Auvray <nicolas.auvray@enovance.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -69,6 +70,9 @@ do
     esac
 done
 
+# User must provide at least non-empty parameters
+[[ -z "${OS_TENANT}" || -z "${OS_USERNAME}" || -z "${OS_PASSWORD}" ]] && (usage; exit 1)
+
 # Set default values
 OS_AUTH_URL=${OS_AUTH_URL:-"http://localhost:5000/v2.0"}
 ENDPOINT_URL=${ENDPOINT_URL:-"http://localhost:9292/v1"}
@@ -86,44 +90,61 @@ then
 fi
 
 # Get a token from Keystone
-TOKEN=$(curl -s -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'" ,"tenant":"'$OS_TENANT'"}}}' -H 'Content-type: application/json' |python -c 'import sys; import json; data = json.loads(sys.stdin.readline()); print data["access"]["token"]["id"]')
-
-if [ -z "$TOKEN" ]; then
-    echo "Unable to get token #1 from Keystone API"
+KS_RESP=$(curl -s -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'" ,"tenant":"'$OS_TENANT'"}}}' -H 'Content-type: application/json' || true)
+if [ ! -z "${KS_RESP}" ]; then
+    TOKEN=$(echo ${KS_RESP} | python -c 'import sys; import json; data = json.loads(sys.stdin.readline()); print data["access"]["token"]["id"]')
+    if [ -z "${TOKEN}" ]; then
+        echo "CRITICAL: Unable to get token #1 from Keystone API"
+        exit $STATE_CRITICAL
+    fi
+else
+    echo "CRITICAL: Unable to reach Keystone API"
     exit $STATE_CRITICAL
 fi
 
 # Use the token to get a tenant ID. By default, it takes the second tenant
-TENANT_ID=$(curl -s -H "X-Auth-Token: $TOKEN" ${OS_AUTH_URL}/tenants |python -c 'import sys; import json; data = json.loads(sys.stdin.readline()); print data["tenants"][0]["id"]')
-
-if [ -z "$TENANT_ID" ]; then
-    echo "Unable to get my tenant ID from Keystone API"
+unset KS_RESP
+KS_RESP=$(curl -s -H "X-Auth-Token: $TOKEN" ${OS_AUTH_URL}/tenants || true)
+if [ ! -z "${KS_RESP}" ]; then
+    TENANT_ID=$(echo ${KS_RESP} | python -c 'import sys; import json; data = json.loads(sys.stdin.readline()); print data["tenants"][0]["id"]')
+    if [ -z "$TENANT_ID" ]; then
+        echo "CRITICAL: Unable to get my tenant ID from Keystone API"
+        exit $STATE_CRITICAL
+    fi
+else
+    echo "CRITICAL: Unable to reach Keystone API"
     exit $STATE_CRITICAL
 fi
 
 # Once we have the tenant ID, we can request a token that will have access to the Glance API
-TOKEN2=$(curl -s -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'"} ,"tenantId":"'$TENANT_ID'"}}' -H 'Content-type: application/json' |python -c 'import sys; import json; data = json.loads(sys.stdin.readline()); print data["access"]["token"]["id"]')
-
-if [ -z "$TOKEN2" ]; then
-    echo "Unable to get token #2 from Keystone API"
+unset KS_RESP
+KS_RESP=$(curl -s -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'"} ,"tenantId":"'$TENANT_ID'"}}' -H 'Content-type: application/json' || true)
+if [ ! -z "${KS_RESP}" ]; then
+    TOKEN2=$(echo ${KS_RESP} | python -c 'import sys; import json; data = json.loads(sys.stdin.readline()); print data["access"]["token"]["id"]')
+    if [ -z "$TOKEN2" ]; then
+        echo "CRITICAL: Unable to get token #2 from Keystone API"
+        exit $STATE_CRITICAL
+    fi
+else
+    echo "CRITICAL: Unable to reach Keystone API"
     exit $STATE_CRITICAL
 fi
 
-START=`date +%s.%N`
-IMAGES=$(curl -s -H "X-Auth-Token: $TOKEN2" -H 'Content-Type: application/json' -H 'User-Agent: python-glanceclient' ${ENDPOINT_URL}/images/detail?sort_key=name&sort_dir=asc&limit=100)
+START=$(date +%s.%N)
+IMAGES=$(curl -s -H "X-Auth-Token: $TOKEN2" -H 'Content-Type: application/json' -H 'User-Agent: python-glanceclient' ${ENDPOINT_URL}/images/detail?sort_key=name&sort_dir=asc&limit=100 || true)
 N_IMAGES=$(echo $IMAGES |  grep -Po '"name":.*?[^\\]",'| wc -l)
-END=`date +%s.%N`
-TIME=`echo ${END} - ${START} | bc`
+END=$(date +%s.%N)
+TIME=$(echo ${END} - ${START} | bc)
 
 if [[ ! "$IMAGES" == *status* ]]; then
-    echo "Unable to list images"
+    echo "CRITICAL: Unable to list images from Glance API"
     exit $STATE_CRITICAL
 else
-    if [ `echo ${TIME}'>'10 | bc -l` -gt 0 ]; then
-        echo "Get images took 10 seconds, it's too long.|response_time=${TIME}"
+    if [ $(echo ${TIME}'>'10 | bc -l) -gt 0 ]; then
+        echo "WARNING: Get images took 10 seconds, it's too long.|response_time=${TIME}"
         exit $STATE_WARNING
     else
-        echo "Get images, Glance API is working: list $N_IMAGES images in $TIME seconds.|response_time=${TIME}"
+        echo "OK: Get images, Glance API is working: list $N_IMAGES images in $TIME seconds.|response_time=${TIME}"
         exit $STATE_OK
     fi
 fi


### PR DESCRIPTION
- Empty response from keystone/glance API is now managed
- Add error handling on empty credentials
