### PR TITLE
[glance] remove python calls in check_glance-api

### DIFF
--- a/scripts/glance/check_glance-api.sh
+++ b/scripts/glance/check_glance-api.sh
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-# Requirement: curl, bc
+# Requirement: curl, bc, awk
 #
 set -e
 
@@ -39,9 +39,12 @@ usage ()
     echo " -T <tenant>          Tenant to use to get an auth token"
     echo " -U <username>        Username to use to get an auth token"
     echo " -P <password>        Password to use to get an auth token"
+    echo " -k <timeout>         Timeout for Keystone APIs calls. Default to 5 seconds"
+    echo " -w <warning>         Warning timeout for Glance APIs calls. Default to 5 seconds"
+    echo " -c <critical>        Critical timeout for Glance APIs calls. Default to 10 seconds"
 }
 
-while getopts 'hH:U:T:P:E:' OPTION
+while getopts 'hH:U:T:P:E:k:w:c:' OPTION
 do
     case $OPTION in
         h)
@@ -63,6 +66,15 @@ do
         P)
             export OS_PASSWORD=$OPTARG
             ;;
+        k)
+            [[ $OPTARG =~ ^[0-9]+$ ]] && export KS_TIMEOUT=$OPTARG || (echo "Timeout must be an entire numeric value"; usage)
+            ;;
+        w)
+            [[ $OPTARG =~ ^[0-9]+$ ]] && export W_TIMEOUT=$OPTARG || (echo "Timeout must be an entire numeric value"; usage)
+            ;;
+        c)
+            [[ $OPTARG =~ ^[0-9]+$ ]] && export C_TIMEOUT=$OPTARG || (echo "Timeout must be an entire numeric value"; usage)
+            ;;
         *)
             usage
             exit 1
@@ -72,6 +84,10 @@ done
 
 # User must provide at least non-empty parameters
 [[ -z "${OS_TENANT}" || -z "${OS_USERNAME}" || -z "${OS_PASSWORD}" ]] && (usage; exit 1)
+# If no timeout is specified
+[[ -z $KS_TIMEOUT ]] && export KS_TIMEOUT=5
+[[ -z $W_TIMEOUT ]] && export W_TIMEOUT=5
+[[ -z $C_TIMEOUT ]] && export C_TIMEOUT=10
 
 # Set default values
 OS_AUTH_URL=${OS_AUTH_URL:-"http://localhost:5000/v2.0"}
@@ -87,9 +103,10 @@ function getJson() {
 # Requirements
 [ ! which curl >/dev/null 2>&1 ] && (echo "curl is not installed.";exit $STATE_UNKNOWN)
 [ ! which bc >/dev/null 2>&1 ] && (echo "bc is not installed.";exit $STATE_UNKNOWN)
+[ ! which awk >/dev/null 2>&1 ] && (echo "awk is not installed.";exit $STATE_UNKNOWN)
 
 # Get a token from Keystone
-KS_RESP=$(curl -s -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'" ,"tenant":"'$OS_TENANT'"}}}' -H 'Content-type: application/json' || true)
+KS_RESP=$(curl -s -m $KS_TIMEOUT -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'" ,"tenant":"'$OS_TENANT'"}}}' -H 'Content-type: application/json' || true)
 if [ ! -z "${KS_RESP}" ]; then
     # We take the first ID value as it represents the keystone token
     TOKEN=$(echo ${KS_RESP} | getJson id 1)
@@ -104,7 +121,7 @@ fi
 
 # Use the token to get a tenant ID. By default, it takes the second tenant
 unset KS_RESP
-KS_RESP=$(curl -s -H "X-Auth-Token: $TOKEN" ${OS_AUTH_URL}/tenants || true)
+KS_RESP=$(curl -s -m $KS_TIMEOUT -H "X-Auth-Token: $TOKEN" ${OS_AUTH_URL}/tenants || true)
 if [ ! -z "${KS_RESP}" ]; then
     TENANT_ID=$(echo ${KS_RESP} | getJson id 1)
     if [ -z "$TENANT_ID" ]; then
@@ -118,7 +135,7 @@ fi
 
 # Once we have the tenant ID, we can request a token that will have access to the Glance API
 unset KS_RESP
-KS_RESP=$(curl -s -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'"} ,"tenantId":"'$TENANT_ID'"}}' -H 'Content-type: application/json' || true)
+KS_RESP=$(curl -s -m $KS_TIMEOUT -X 'POST' ${OS_AUTH_URL}/tokens -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password":"'$OS_PASSWORD'"} ,"tenantId":"'$TENANT_ID'"}}' -H 'Content-type: application/json' || true)
 if [ ! -z "${KS_RESP}" ]; then
     TOKEN2=$(echo ${KS_RESP} | getJson id 1)
     if [ -z "$TOKEN2" ]; then
@@ -131,17 +148,20 @@ else
 fi
 
 START=$(date +%s.%N)
-IMAGES=$(curl -s -H "X-Auth-Token: $TOKEN2" -H 'Content-Type: application/json' -H 'User-Agent: python-glanceclient' ${ENDPOINT_URL}/images/detail?sort_key=name&sort_dir=asc&limit=100 || true)
+IMAGES=$(curl -s -m $C_TIMEOUT -H "X-Auth-Token: $TOKEN2" -H 'Content-Type: application/json' -H 'User-Agent: python-glanceclient' ${ENDPOINT_URL}/images/detail?sort_key=name&sort_dir=asc&limit=10 || true)
 N_IMAGES=$(echo $IMAGES |  grep -Po '"name":.*?[^\\]",'| wc -l)
 END=$(date +%s.%N)
 TIME=$(echo ${END} - ${START} | bc)
 
-if [[ ! "$IMAGES" == *status* ]]; then
+if [[ -z $IMAGES ]]; then
+    echo "CRITICAL: Unable to contact Glance API. Either Glance service is not running or timeout of ${C_TIMEOUT}s has been reached."
+    exit $STATE_CRITICAL
+elif [[ ! "$IMAGES" == *status* ]]; then
     echo "CRITICAL: Unable to list images from Glance API"
     exit $STATE_CRITICAL
 else
-    if [ $(echo ${TIME}'>'10 | bc -l) -gt 0 ]; then
-        echo "WARNING: Get images took 10 seconds, it's too long.|response_time=${TIME}"
+    if [ $(echo ${TIME}'>'$W_TIMEOUT | bc -l) -gt 0 ]; then
+        echo "WARNING: Get images took more than $W_TIMEOUT seconds, it's too long.|response_time=${TIME}"
         exit $STATE_WARNING
     else
         echo "OK: Get images, Glance API is working: list $N_IMAGES images in $TIME seconds.|response_time=${TIME}"


### PR DESCRIPTION
- Keystone tokens in json response are now extracted via bash function and magic AWK
- No more piping to python to avoid dirty tracebacks when API is buggy
- User has now to provide non-empty parameters
- Messages are more verbose
- Add options to specify timeout for keystone/glance API
- Requirements have been updated
