### PR TITLE
utils: add check_process_exists method

### DIFF
--- a/oschecks/process.py
+++ b/oschecks/process.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+# Openstack Monitoring script for Sensu / Nagios
+#
+# Copyright © 2013-2014 eNovance <licensing@enovance.com>
+#
+# Author: Emilien Macchi <emilien.macchi@enovance.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import argparse
+
+from oschecks import utils
+
+
+def check_process():
+    parser = argparse.ArgumentParser(
+        description='Check process existence of an OpenStack service.')
+    parser.add_argument(dest='process_name',
+                        help='Process name')
+    options = parser.parse_args()
+    utils.check_process_exists(options.process_name)
+
+
+def main():
+    utils.safe_run(check_process)

--- a/oschecks/utils.py
+++ b/oschecks/utils.py
@@ -83,6 +83,14 @@ def check_process_exists_and_amqp_connected(name):
     critical("%s is not connected to AMQP" % name)
 
 
+def check_process_exists(name):
+    processes = filter(lambda p: check_process_name(name, p),
+                       psutil.process_iter())
+    if not processes:
+        critical("%s is not running" % name)
+    ok("%s is working." % name)
+
+
 def timeit_wrapper(func):
     def wrapper(*arg, **kw):
         t1 = time.time()


### PR DESCRIPTION
Sometimes, some services need to be monitored only by checking if the
process is running well or not.
This patch add a new method for this and process.py to use this method.

The use case is for example Ceilometer Compute Agent where we currently
just need to validate the service is running as a process.
