### PR TITLE
Support of openstack-swift from liberty

### DIFF
--- a/scripts/swift/check_swift_dispersion
+++ b/scripts/swift/check_swift_dispersion
@@ -37,23 +37,20 @@ with os.popen("swift-dispersion-report -j %s" \
 
 msgs = []
 state = STATE_OK
+missing_critical = int(os.getenv("SWIFT_DISPERSION_MISSING_CRITICAL", 3))
 
 # type_ is either "objects", "container"
 for type_, values in stats.iteritems():
 
     msgs.append("%.2f%% %ss found" % (values['pct_found'], type_))
 
-    if values['missing_one'] > 0:
-        msgs.append("%d %ss missing one copy" % (values['missing_one'], type_))
-        state = max(state, STATE_WARNING)
-
-    if values['missing_two'] > 0:
-        msgs.append("%d %ss missing two copies" % (values['missing_two'], type_))
-        state = max(state, STATE_WARNING)
-
-    if values['missing_all'] > 0:
-        msgs.append("%d %ss missing ALL copies" % (values['missing_all'], type_))
-        state = max(state, STATE_CRITICAL)
+    for i in range(1,missing_critical+1):
+        if values.get("missing_%i" % i, 0) > 0:
+            msgs.append("%d %ss missing %i copies" % (values["missing_%i" % i], type_, i))
+            if i >= missing_critical:
+                state = max(state, STATE_CRITICAL)
+            else:
+                state = max(state, STATE_WARNING)
 
 print ", ".join(msgs)
 sys.exit(state)

--- a/scripts/swift/check_swift_dispersion
+++ b/scripts/swift/check_swift_dispersion
@@ -24,6 +24,7 @@
 import os
 import sys
 import json
+from sys import argv
 
 STATE_OK=0
 STATE_WARNING=1
@@ -31,13 +32,19 @@ STATE_CRITICAL=2
 STATE_UNKNOWN=3
 STATE_DEPENDENT=4
 
+dispersion_config = os.getenv("SWIFT_DISPERSION_CONFIG", "/etc/swift/swift.conf")
+if len(argv) > 1:
+    dispersion_config = argv[1]
+
 with os.popen("swift-dispersion-report -j %s" \
-                  % os.getenv("SWIFT_DISPERSION_CONFIG", "/etc/swift/swift.conf")) as report:
+                  % dispersion_config) as report:
     stats = json.load(report)
 
 msgs = []
 state = STATE_OK
 missing_critical = int(os.getenv("SWIFT_DISPERSION_MISSING_CRITICAL", 3))
+if len(argv) > 2:
+    missing_critical = int(argv[2])
 
 # type_ is either "objects", "container"
 for type_, values in stats.iteritems():


### PR DESCRIPTION
I have openstack-swift liberty and i have some issues with some checks:
# /etc/scripts/check_swift_object_servers

Usage: 
        usage: swift-recon <server_type> [-v] [--suppress] [-a] [-r] [-u] [-d]
        [-l] [-T] [--md5] [--auditor] [--updater] [--expirer] [--sockstat]
        [--human-readable]

```
    <server_type>   account|container|object
    Defaults to object server.

    ex: swift-recon container -l --auditor
```

swift-recon: error: no such option: --objmd5
# /etc/scripts/check_swift_dispersion  /etc/swift/dispersion.conf

/usr/lib/python2.7/site-packages/keystoneclient/service_catalog.py:196: UserWarning: Providing attr without filter_value to get_urls() is deprecated as of the 1.7.0 release and may be removed in the 2.0.0 release. Either both should be provided or neither should be provided.
  'Providing attr without filter_value to get_urls() is '
Traceback (most recent call last):
  File "/etc/scripts/check_swift_dispersion", line 41, in <module>
    stats = json.load(report)
  File "/usr/lib64/python2.7/json/**init**.py", line 290, in load
    **kw)
  File "/usr/lib64/python2.7/json/**init**.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 383, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded

So i propose the following changes:

--- check_swift_dispersion.orig 2015-10-28 12:25:13.295319852 +0000
+++ check_swift_dispersion  2015-10-28 12:26:04.662768280 +0000
@@ -32,11 +32,11 @@
 STATE_UNKNOWN=3
 STATE_DEPENDENT=4

-dispersion_config = os.getenv("SWIFT_DISPERSION_CONFIG", "/etc/swift/swift.conf")
+dispersion_config = os.getenv("SWIFT_DISPERSION_CONFIG", "/etc/swift/dispersion.conf")
 if len(argv) > 1:
     dispersion_config = argv[1]

-with os.popen("swift-dispersion-report -j %s" \
+with os.popen("swift-dispersion-report -j %s | grep \"^{\"" \
                   % dispersion_config) as report:
     stats = json.load(report)

--- check_swift_object_servers.orig 2015-10-28 12:24:55.335163069 +0000
+++ check_swift_object_servers  2015-10-28 12:25:00.839211116 +0000
@@ -56,7 +56,7 @@
     exit $STATE_UNKNOWN
 fi

-CHECK=$(swift-recon --objmd5 | grep ' error')
+CHECK=$(swift-recon --md5 | grep ' error')
 echo $CHECK

 if echo "$CHECK" | grep -q ' 0 error'
